### PR TITLE
Refactor modules into separate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/database.py
+++ b/database.py
@@ -1,0 +1,17 @@
+"""Simple database module."""
+
+class Database:
+    """Represents a minimal database connection."""
+
+    def __init__(self, connection_string: str):
+        self.connection_string = connection_string
+        self.connected = False
+
+    def connect(self) -> None:
+        """Simulate establishing a database connection."""
+        # In a real implementation, connection logic would go here.
+        self.connected = True
+
+    def close(self) -> None:
+        """Simulate closing the database connection."""
+        self.connected = False

--- a/download_manager.py
+++ b/download_manager.py
@@ -1,0 +1,37 @@
+"""Download manager module."""
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class DownloadItem:
+    """Represents an item to download."""
+    url: str
+    destination: str
+
+
+class DownloadTask:
+    """A task that performs a download."""
+
+    def __init__(self, item: DownloadItem):
+        self.item = item
+        self.completed = False
+
+    def run(self) -> None:
+        """Simulate performing the download."""
+        # Real download code would go here.
+        self.completed = True
+
+
+class DownloadManager:
+    """Coordinates download tasks."""
+
+    def __init__(self) -> None:
+        self.tasks: List[DownloadTask] = []
+
+    def add_task(self, task: DownloadTask) -> None:
+        self.tasks.append(task)
+
+    def run_all(self) -> None:
+        for task in self.tasks:
+            task.run()

--- a/rom_manager.py
+++ b/rom_manager.py
@@ -1,0 +1,25 @@
+"""Entry point for the ROM Manager application."""
+from database import Database
+from download_manager import DownloadItem, DownloadManager, DownloadTask
+from ui_main import MainWindow
+
+
+def main() -> None:
+    """Run the application."""
+    db = Database("sqlite:///roms.db")
+    db.connect()
+
+    manager = DownloadManager()
+    item = DownloadItem(url="http://example.com/rom.zip", destination="rom.zip")
+    task = DownloadTask(item)
+    manager.add_task(task)
+    manager.run_all()
+
+    window = MainWindow()
+    window.build_tabs()
+
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,0 +1,14 @@
+"""User interface module."""
+from typing import List
+
+
+class MainWindow:
+    """Represents the main application window."""
+
+    def __init__(self) -> None:
+        self.tabs: List[str] = []
+
+    def build_tabs(self) -> None:
+        """Simulate constructing UI tabs."""
+        # In a real GUI application, this would construct the actual tabs.
+        self.tabs = ["Downloads", "Database"]


### PR DESCRIPTION
## Summary
- Separate database, download management, and UI logic into dedicated modules
- Provide a main entrypoint that imports the new modules
- Add a basic `.gitignore` for Python artifacts

## Testing
- `python -m py_compile database.py download_manager.py ui_main.py rom_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b99b8f28bc8328a5c2bd0dee93c0cc