### PR TITLE
Enable running project as package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,5 @@
+"""ROM Manager package."""
+
+from .rom_manager import main
+
+__all__ = ["main"]

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running the package with `python -m RomManagerAB`."""
+
+from .rom_manager import main
+
+if __name__ == "__main__":
+    main()

--- a/rom_manager.py
+++ b/rom_manager.py
@@ -1,7 +1,13 @@
 """Entry point for the ROM Manager application."""
-from database import Database
-from download_manager import DownloadItem, DownloadManager, DownloadTask
-from ui_main import MainWindow
+
+try:  # pragma: no cover - import fallback logic
+    from .database import Database
+    from .download_manager import DownloadItem, DownloadManager, DownloadTask
+    from .ui_main import MainWindow
+except ImportError:  # pragma: no cover - support running as a script
+    from database import Database
+    from download_manager import DownloadItem, DownloadManager, DownloadTask
+    from ui_main import MainWindow
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- Add package `__init__` exposing `main`
- Provide `__main__` module so project runs with `python -m RomManagerAB`
- Allow `rom_manager.py` to work both as script and as module

## Testing
- `python rom_manager.py`
- `python -m RomManagerAB`


------
https://chatgpt.com/codex/tasks/task_e_68b9ab6d7ba0832892e1288003ab5124