### PR TITLE
Add global exception logging

### DIFF
--- a/rom_manager/main.py
+++ b/rom_manager/main.py
@@ -1,21 +1,70 @@
-"""
-Punto de entrada independiente para la aplicación ROM Manager.
+"""Punto de entrada independiente para la aplicación ROM Manager.
 
-Este módulo crea y ejecuta la aplicación PyQt6 utilizando la clase
-MainWindow definida en Descargador.py. Separar el punto de entrada
-facilita la estructura del proyecto y permite importar la interfaz
-gráfica sin ejecutar la aplicación de inmediato.
+Este módulo prepara la configuración de logging, captura excepciones no
+controladas y crea la aplicación PyQt6 utilizando la clase ``MainWindow``
+definida en :mod:`Descargador`. Separar el punto de entrada facilita la
+estructura del proyecto y permite importar la interfaz gráfica sin ejecutar la
+aplicación de inmediato.
 """
+
+from __future__ import annotations
 
 import sys
-from PyQt6.QtWidgets import QApplication
-from .Descargador import MainWindow
+import logging
+from pathlib import Path
+
+
+def _setup_logging() -> None:
+    """Configura el logging para consola y archivo ``log.txt``.
+
+    Se establece un ``sys.excepthook`` personalizado para capturar cualquier
+    excepción no manejada y registrarla, de modo que el programa no se cierre
+    silenciosamente.
+    """
+
+    log_file = Path(__file__).resolve().parent.parent / "log.txt"
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(log_file, encoding="utf-8"),
+            logging.StreamHandler(sys.stdout),
+        ],
+    )
+
+    def handle_exception(exc_type, exc_value, exc_traceback) -> None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            # Permitir que el usuario interrumpa la ejecución sin stacktrace
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+        logging.exception(
+            "Unhandled exception",
+            exc_info=(exc_type, exc_value, exc_traceback),
+        )
+
+    sys.excepthook = handle_exception
+
 
 def main() -> None:
-    app = QApplication(sys.argv)
+    _setup_logging()
+    from PyQt6.QtWidgets import QApplication  # Importar tras configurar logging
+    from .Descargador import MainWindow
+
+    class Application(QApplication):
+        """Subclase que captura excepciones en el bucle de eventos de Qt."""
+
+        def notify(self, receiver, event):  # type: ignore[override]
+            try:
+                return super().notify(receiver, event)
+            except Exception:  # pragma: no cover - solo para depuración
+                logging.exception("Unhandled exception in Qt event loop")
+                return False
+
+    app = Application(sys.argv)
     win = MainWindow()
     win.show()
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- log unhandled exceptions to log.txt and console
- guard Qt event loop with exception handler

## Testing
- `python -m py_compile rom_manager/main.py rom_manager/Descargador.py`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'\nfrom rom_manager.main import main\nimport threading, time, sys\n\ndef run():\n    try:\n        main()\n    except SystemExit:\n        pass\n\nthread = threading.Thread(target=run)\nthread.start()\ntime.sleep(1)\nif thread.is_alive():\n    print('App still running; attempting to terminate')\nthread.join(timeout=1)\nprint('Test finished')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68bab4c1857c8328ba74adff7c3e0e8e