### PR TITLE
Warn before exiting with active downloads

### DIFF
--- a/rom_manager/gui/main_window.py
+++ b/rom_manager/gui/main_window.py
@@ -49,6 +49,9 @@ class MainWindow(QMainWindow):
         self.model = LinksTableModel([])
         self.manager = DownloadManager(self.pool, 3)
         self.manager.queue_changed.connect(self._refresh_downloads_table)
+        # Seguir descargas en segundo plano
+        self.manager.queue_changed.connect(self._check_background_downloads)
+        self.background_downloads: bool = False
         self.items: List[DownloadItem] = []
 
         # Cesta de descargas (agrupa ROMs) y estructura de búsqueda
@@ -916,6 +919,16 @@ class MainWindow(QMainWindow):
         """Este slot se puede usar para actualizar contadores globales si fuera necesario."""
         pass
 
+    def _check_background_downloads(self) -> None:
+        """Cierra la aplicación cuando las descargas en segundo plano finalizan."""
+        if self.background_downloads and not self.manager._active and not self.manager._queue:
+            try:
+                self._save_session_silent()
+                self._save_config()
+            except Exception:
+                pass
+            QApplication.instance().quit()
+
     # --- Persistencia de sesión (Ajustes de descarga) ---
     def _session_path(self) -> str:
         """Devuelve la ruta del fichero de sesión en la carpeta de descargas."""
@@ -1623,7 +1636,25 @@ class MainWindow(QMainWindow):
 
     # --- Evento de cierre ---
     def closeEvent(self, event) -> None:
-        """Sobrecarga para guardar configuración, cesta y sesión automáticamente al cerrar."""
+        """Pregunta al usuario si desea salir cuando hay descargas activas."""
+        if self.manager._active or self.manager._queue:
+            box = QMessageBox(self)
+            box.setWindowTitle("Descargas en curso")
+            box.setText("Hay descargas en curso. ¿Quieres salir?")
+            box.setIcon(QMessageBox.Icon.Warning)
+            box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+            chk = QCheckBox("Seguir descargando en segundo plano")
+            box.setCheckBox(chk)
+            resp = box.exec()
+            if resp == QMessageBox.StandardButton.Yes:
+                if chk.isChecked():
+                    self.background_downloads = True
+                    self.hide()
+                    event.ignore()
+                    return
+            else:
+                event.ignore()
+                return
         try:
             # Guardar sesión y configuración de manera silenciosa
             self._save_session_silent()


### PR DESCRIPTION
## Summary
- warn user when exiting with downloads in progress and offer background mode
- close app automatically after background downloads finish

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68babb3d7de883289508ad7cd36a8430