### PR TITLE
Fix QStyle import location

### DIFF
--- a/rom_manager/gui/main_window.py
+++ b/rom_manager/gui/main_window.py
@@ -14,9 +14,9 @@ from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, QLabel, QLineEdit,
     QPushButton, QFileDialog, QGroupBox, QComboBox, QSpinBox, QTableView, QTableWidget,
     QTableWidgetItem, QHeaderView, QMessageBox, QProgressBar, QCheckBox, QTabWidget,
-    QAbstractItemView, QMenu
+    QAbstractItemView, QMenu, QStyle
 )
-from PyQt6.QtGui import QDesktopServices, QStyle
+from PyQt6.QtGui import QDesktopServices
 
 from ..database import Database
 from ..models import LinksTableModel


### PR DESCRIPTION
## Summary
- fix QStyle import by moving it from QtGui to QtWidgets

## Testing
- `python -m rom_manager.main` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bad81e4ff883289552e515976331a0