### PR TITLE
Add region search filter

### DIFF
--- a/rom_manager/database.py
+++ b/rom_manager/database.py
@@ -63,6 +63,15 @@ class Database:
         cur = self.conn.execute("SELECT id, code FROM languages ORDER BY code")
         return [(None, "Todos")] + [(r[0], r[1]) for r in cur.fetchall()]
 
+    def get_regions(self) -> List[Tuple[Optional[int], str]]:
+        """
+        Devuelve la lista de regiones disponibles para el filtro.
+        El primer elemento de la lista corresponde a "Todos" (sin filtro).
+        """
+        assert self.conn
+        cur = self.conn.execute("SELECT id, code FROM regions ORDER BY code")
+        return [(None, "Todos")] + [(r[0], r[1]) for r in cur.fetchall()]
+
     def get_formats(self) -> List[str]:
         """
         Devuelve la lista de formatos de archivo distintos disponibles.
@@ -79,6 +88,7 @@ class Database:
         text: str = "",
         system_id: Optional[int] = None,
         language_id: Optional[int] = None,
+        region_id: Optional[int] = None,
         fmt: Optional[str] = None,
         limit: int = 1000,
     ) -> List[sqlite3.Row]:
@@ -89,6 +99,7 @@ class Database:
         :param text: Texto de búsqueda para coincidir con nombre de ROM, etiqueta o servidor.
         :param system_id: Identificador del sistema seleccionado (None para todos).
         :param language_id: Identificador del idioma seleccionado (None para todos).
+        :param region_id: Identificador de la región seleccionada (None para todos).
         :param fmt: Formato de archivo seleccionado (None o "Todos" para todos).
         :param limit: Máximo número de resultados a devolver.
         :return: Lista de filas con información relevante para cada enlace de descarga.
@@ -108,6 +119,9 @@ class Database:
                 "EXISTS (SELECT 1 FROM link_languages ll WHERE ll.link_id = links.id AND ll.language_id = ?)"
             )
             params.append(language_id)
+        if region_id is not None:
+            where.append("roms.region_id = ?")
+            params.append(region_id)
         if fmt is not None and fmt != "Todos":
             where.append("links.fmt = ?")
             params.append(fmt)

--- a/rom_manager/gui/main_window.py
+++ b/rom_manager/gui/main_window.py
@@ -218,13 +218,14 @@ class MainWindow(QMainWindow):
         # Grupo de filtros y búsqueda
         filters = QGroupBox("Búsqueda y filtros"); f = QGridLayout(filters)
         self.le_search = QLineEdit(); self.le_search.setPlaceholderText("Buscar por ROM/etiqueta/servidor…")
-        self.cmb_system = QComboBox(); self.cmb_lang = QComboBox(); self.cmb_fmt = QComboBox()
+        self.cmb_system = QComboBox(); self.cmb_lang = QComboBox(); self.cmb_region = QComboBox(); self.cmb_fmt = QComboBox()
         self.btn_search = QPushButton("Buscar"); self.btn_search.clicked.connect(self._run_search)
         f.addWidget(QLabel("Texto:"),0,0); f.addWidget(self.le_search,0,1)
         f.addWidget(QLabel("Sistema:"),1,0); f.addWidget(self.cmb_system,1,1)
         f.addWidget(QLabel("Idioma:"),2,0); f.addWidget(self.cmb_lang,2,1)
-        f.addWidget(QLabel("Formato:"),3,0); f.addWidget(self.cmb_fmt,3,1)
-        f.addWidget(self.btn_search,0,2,4,1)
+        f.addWidget(QLabel("Región:"),3,0); f.addWidget(self.cmb_region,3,1)
+        f.addWidget(QLabel("Formato:"),4,0); f.addWidget(self.cmb_fmt,4,1)
+        f.addWidget(self.btn_search,0,2,5,1)
         lay.addWidget(filters)
 
         # Tabla de resultados agrupados: columnas ROM, Servidor, Formato, Idiomas, Acciones
@@ -336,10 +337,11 @@ class MainWindow(QMainWindow):
             QMessageBox.critical(self, "Error BD", str(e))
 
     def _load_filters(self) -> None:
-        """Carga los valores de los filtros (sistemas, idiomas, formatos) en los combobox."""
+        """Carga los valores de los filtros (sistemas, idiomas, regiones, formatos) en los combobox."""
         assert self.db
         self.cmb_system.clear(); [self.cmb_system.addItem(n, i) for i,n in self.db.get_systems()]
         self.cmb_lang.clear();   [self.cmb_lang.addItem(c, i) for i,c in self.db.get_languages()]
+        self.cmb_region.clear(); [self.cmb_region.addItem(c, i) for i,c in self.db.get_regions()]
         self.cmb_fmt.clear();    [self.cmb_fmt.addItem(x) for x in self.db.get_formats()]
 
     def _run_search(self) -> None:
@@ -354,10 +356,13 @@ class MainWindow(QMainWindow):
         text = self.le_search.text().strip()
         sys_id = self.cmb_system.currentData()
         lang_id = self.cmb_lang.currentData()
+        region_id = self.cmb_region.currentData()
         fmt_val = self.cmb_fmt.currentText(); fmt = None if fmt_val == 'Todos' else fmt_val
         try:
-            rows = self.db.search_links(text, sys_id, lang_id, fmt)
-            logging.debug(f"Search returned {len(rows)} rows for '{text}' with filters system={sys_id}, lang={lang_id}, fmt={fmt}.")
+            rows = self.db.search_links(text, sys_id, lang_id, region_id, fmt)
+            logging.debug(
+                f"Search returned {len(rows)} rows for '{text}' with filters system={sys_id}, lang={lang_id}, region={region_id}, fmt={fmt}."
+            )
         except Exception as e:
             logging.exception("Error during search: %s", e)
             QMessageBox.critical(self, "Búsqueda", str(e))


### PR DESCRIPTION
## Summary
- support region-based filtering by querying regions and ROM region IDs
- expose new region combobox in the selector UI and include region when running searches

## Testing
- `python -m py_compile rom_manager/database.py rom_manager/gui/main_window.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baea16f7fc83289fafa015a1f3b129