### PR TITLE
Fix region filter in search query

### DIFF
--- a/rom_manager/database.py
+++ b/rom_manager/database.py
@@ -120,7 +120,9 @@ class Database:
             )
             params.append(language_id)
         if region_id is not None:
-            where.append("roms.region_id = ?")
+            where.append(
+                "EXISTS (SELECT 1 FROM rom_regions rr WHERE rr.rom_id = roms.id AND rr.region_id = ?)"
+            )
             params.append(region_id)
         if fmt is not None and fmt != "Todos":
             where.append("links.fmt = ?")


### PR DESCRIPTION
## Summary
- ensure region filter uses rom_regions table instead of missing roms.region_id

## Testing
- `python -m py_compile rom_manager/database.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb10c436d08328893fb0d6a03fee99