### PR TITLE
Fix progress overflow for large downloads

### DIFF
--- a/rom_manager/download.py
+++ b/rom_manager/download.py
@@ -26,7 +26,8 @@ class DownloadSignals(QObject):
     Conjunto de señales para notificar progreso, éxito y fallos durante la descarga.
     """
 
-    progress = pyqtSignal(int, int, float, float, str)  # done, total, speed, eta, status
+    # Use 64-bit integers for progress values to support files larger than 2 GiB
+    progress = pyqtSignal('qint64', 'qint64', float, float, str)  # done, total, speed, eta, status
     finished_ok = pyqtSignal(str)
     failed = pyqtSignal(str)
 


### PR DESCRIPTION
## Summary
- prevent 32-bit overflow when reporting download progress for large files by emitting progress as 64-bit integers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc10ae4b408328bbceb17233ab4dcf