### PR TITLE
Add icon flag to PyInstaller build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,8 +9,11 @@ Para generar el ejecutable con PyInstaller desde la raíz del repositorio se
 puede utilizar el siguiente comando en una sola línea:
 
 ```
-pyinstaller --noconfirm --clean --name "RomManager" --add-data "resources/romMan.ico;resources" --windowed rom_manager/main.py
+pyinstaller --noconfirm --clean --name=RomManager --icon=resources/romMan.ico --add-data "resources/romMan.ico;resources" --windowed rom_manager/main.py
 ```
+
+El parámetro ``--icon`` asigna el icono ``romMan.ico`` al ejecutable generado,
+mientras que ``--name`` define el nombre final del binario.
 
 El ejecutable resultante heredará la misma estructura de carpetas cuando se
 publique o distribuya.


### PR DESCRIPTION
## Summary
- update the PyInstaller command in BUILDING.md to use the --icon flag with romMan.ico and keep the executable name consistent
- document what the --icon and --name parameters do in the build instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c1f9ed948328b9e1fcc1e46d19c8