### PR TITLE
Add PyInstaller spec to bundle icon correctly

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,14 +6,18 @@ ellas se guardan los registros (`logs/rom_manager.log`), la configuración en
 JSON (`config/settings.json`) y las sesiones de descarga (`sessions/*.json`).
 
 Para generar el ejecutable con PyInstaller desde la raíz del repositorio se
-puede utilizar el siguiente comando en una sola línea:
+incluye el archivo ``RomManager.spec``. Dicho spec fija la ruta del icono y de
+los recursos utilizando rutas absolutas, evitando errores cuando el comando se
+lanza desde otro directorio. Basta con ejecutar:
 
 ```
-pyinstaller --noconfirm --clean --name=RomManager --icon=resources/romMan.ico --add-data "resources/romMan.ico;resources" --windowed rom_manager/main.py
+pyinstaller --noconfirm --clean RomManager.spec
 ```
 
-El parámetro ``--icon`` asigna el icono ``romMan.ico`` al ejecutable generado,
-mientras que ``--name`` define el nombre final del binario.
+PyInstaller leerá el spec y generará el binario ``RomManager/RomManager.exe``
+con el icono ``romMan.ico`` incrustado, además de copiar el fichero en la
+carpeta ``resources`` del directorio de salida para que la aplicación pueda
+referenciarlo.
 
 El ejecutable resultante heredará la misma estructura de carpetas cuando se
 publique o distribuya.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The *Emulators* tab offers a filtered dropdown per system, notes, and extra down
 Add items from search results or the basket to the queue. The manager enforces concurrency limits, streams to `.part` files, and swaps them atomically once finished. You can persist and restore sessions, enabling long-term batch transfers without losing progress.【F:rom_manager/download.py†L1-L341】【F:rom_manager/gui/main_window.py†L118-L207】【F:rom_manager/gui/main_window.py†L1408-L1546】
 
 ### Building a desktop release
-Create a standalone executable with PyInstaller:
+Create a standalone executable with PyInstaller using the bundled spec file:
 ```bash
-pyinstaller --noconfirm --clean --name "RomManager" --add-data "resources/romMan.ico;resources" --windowed rom_manager/main.py
+pyinstaller --noconfirm --clean RomManager.spec
 ```
 The generated binary recreates the same directory layout (`logs/`, `config/`, `sessions/`) alongside the executable when shipped.【F:BUILDING.md†L1-L14】
 
@@ -81,9 +81,9 @@ La pestaña *Emuladores* ofrece desplegables filtrados por sistema, notas y enla
 Añade elementos desde los resultados o la cesta a la cola. El gestor respeta el límite de concurrencia, escribe en archivos `.part` y los reemplaza al terminar. Puedes guardar y restaurar sesiones para reanudar lotes largos sin perder progreso.【F:rom_manager/download.py†L1-L341】【F:rom_manager/gui/main_window.py†L118-L207】【F:rom_manager/gui/main_window.py†L1408-L1546】
 
 ### Generar un ejecutable de escritorio
-Crea un ejecutable independiente con PyInstaller:
+Crea un ejecutable independiente con PyInstaller utilizando el spec incluido:
 ```bash
-pyinstaller --noconfirm --clean --name "RomManager" --add-data "resources/romMan.ico;resources" --windowed rom_manager/main.py
+pyinstaller --noconfirm --clean RomManager.spec
 ```
 El binario generado recrea la misma estructura de carpetas (`logs/`, `config/`, `sessions/`) junto al ejecutable al distribuirlo.【F:BUILDING.md†L1-L14】
 

--- a/RomManager.spec
+++ b/RomManager.spec
@@ -1,0 +1,62 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+"""Spec de PyInstaller para generar el ejecutable de ROM Manager."""
+
+from pathlib import Path
+
+# Resolvemos rutas absolutas para que PyInstaller pueda localizar los recursos
+# aunque se invoque desde otro directorio.
+BASE_DIR = Path(__file__).resolve().parent
+ICON_PATH = BASE_DIR / "resources" / "romMan.ico"
+
+block_cipher = None
+
+
+a = Analysis(
+    ['rom_manager/main.py'],
+    pathex=[str(BASE_DIR)],
+    binaries=[],
+    datas=[(str(ICON_PATH), 'resources')],
+    hiddenimports=[],
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='RomManager',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=str(ICON_PATH),
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='RomManager',
+)


### PR DESCRIPTION
## Summary
- add a dedicated `RomManager.spec` that resolves the icon path and bundles the resource folder for PyInstaller
- update BUILDING.md and README instructions to use the new spec when creating the Windows executable

## Testing
- python -m compileall rom_manager

------
https://chatgpt.com/codex/tasks/task_e_68c9c42225d08328826ab61c389fe79e