### PR TITLE
Fix PyInstaller spec base dir resolution

### DIFF
--- a/RomManager.spec
+++ b/RomManager.spec
@@ -4,9 +4,24 @@
 
 from pathlib import Path
 
+
+def _resolve_base_dir() -> Path:
+    """Obtiene el directorio base del proyecto.
+
+    Cuando PyInstaller ejecuta el ``spec`` el nombre ``__file__`` no siempre
+    está definido, por lo que calculamos la ruta a partir del directorio de
+    trabajo actual como alternativa.
+    """
+
+    try:
+        return Path(__file__).resolve().parent  # type: ignore[name-defined]
+    except NameError:
+        return Path.cwd()
+
+
 # Resolvemos rutas absolutas para que PyInstaller pueda localizar los recursos
 # aunque se invoque desde otro directorio.
-BASE_DIR = Path(__file__).resolve().parent
+BASE_DIR = _resolve_base_dir()
 ICON_PATH = BASE_DIR / "resources" / "romMan.ico"
 
 block_cipher = None


### PR DESCRIPTION
## Summary
- ensure the PyInstaller spec resolves the project directory even when `__file__` is undefined
- keep the icon path resolution working so the executable bundles `romMan.ico`

## Testing
- python -m PyInstaller RomManager.spec *(fails: PyInstaller is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cc7886488328bc40d556d20f3166