### PR TITLE
Improve emulator download feedback and fix extraction progress

### DIFF
--- a/rom_manager/utils.py
+++ b/rom_manager/utils.py
@@ -37,7 +37,11 @@ def resource_path(relative_path: str) -> str:
     return str((base_path / relative_path).resolve())
 
 
-def extract_archive(archive_path: str, dest_dir: str) -> None:
+def extract_archive(
+    archive_path: str,
+    dest_dir: str,
+    progress: Optional[Callable[[int, int, str], None]] = None,
+) -> None:
 
     """Descomprime ``archive_path`` en ``dest_dir``.
 


### PR DESCRIPTION
## Summary
- add a feedback panel in the emulator tab to confirm when emulators and extras are queued
- provide contextual messaging for emulator extras and surface duplicate selections
- fix `extract_archive` to accept an optional progress callback required by extraction tasks

## Testing
- python -m compileall rom_manager

------
https://chatgpt.com/codex/tasks/task_e_68c9e3695e8c8328a5139a4f14fbc936