### PR TITLE
Bundle py7zr dependencies in PyInstaller build

### DIFF
--- a/RomManager.spec
+++ b/RomManager.spec
@@ -4,6 +4,8 @@
 
 from pathlib import Path
 
+from PyInstaller.utils.hooks import collect_submodules
+
 
 def _resolve_base_dir() -> Path:
     """Obtiene el directorio base del proyecto.
@@ -27,12 +29,20 @@ ICON_PATH = BASE_DIR / "resources" / "romMan.ico"
 block_cipher = None
 
 
+_py7zr_hidden = collect_submodules('py7zr')
+# py7zr depende de módulos auxiliares que no siempre detecta PyInstaller.
+# ``collect_submodules`` asegura que todo el soporte para 7z quede incluido
+# en el ejecutable generado y evita errores en tiempo de ejecución al extraer
+# archivos .7z.
+_py7zr_hidden += collect_submodules('pybcj')
+_py7zr_hidden += collect_submodules('pyppmd')
+
 a = Analysis(
     ['rom_manager/main.py'],
     pathex=[str(BASE_DIR)],
     binaries=[],
     datas=[(str(ICON_PATH), 'resources')],
-    hiddenimports=[],
+    hiddenimports=_py7zr_hidden,
     hookspath=[],
     runtime_hooks=[],
     excludes=[],


### PR DESCRIPTION
## Summary
- ensure the PyInstaller spec collects all py7zr-related modules
- prevent missing dependency errors when extracting .7z archives in the packaged app

## Testing
- python -m compileall rom_manager

------
https://chatgpt.com/codex/tasks/task_e_68ca47aca4bc8328b298569c1b729a15