### PR TITLE
Ensure py7zr is bundled with PyInstaller builds

### DIFF
--- a/rom_manager/utils.py
+++ b/rom_manager/utils.py
@@ -39,6 +39,23 @@ def resource_path(relative_path: str) -> str:
 
 _PY7ZR_MODULE: ModuleType | None = None
 _PY7ZR_IMPORT_ERROR: BaseException | None = None
+
+try:  # pragma: no cover - depende de la instalación de py7zr
+    import py7zr as _py7zr_preloaded  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - depende del entorno
+    _PY7ZR_IMPORT_ERROR = exc
+except Exception as exc:  # pragma: no cover - depende del entorno
+    _PY7ZR_IMPORT_ERROR = exc
+else:  # pragma: no cover - depende del entorno
+    _PY7ZR_MODULE = _py7zr_preloaded
+    try:  # pragma: no cover - depende de py7zr y sus extras
+        import pybcj  # type: ignore  # noqa: F401  # Referencia explícita para PyInstaller
+        import pyppmd  # type: ignore  # noqa: F401  # Referencia explícita para PyInstaller
+    except ModuleNotFoundError:
+        # Los códecs extra no siempre están disponibles, pero al intentar
+        # importarlos aquí le damos una pista a PyInstaller cuando sí lo están.
+        pass
+
 _PY7ZR_REQUIRED_MSG = (
     "py7zr es necesario para extraer archivos .7z. "
     "Instálalo con `pip install py7zr`."


### PR DESCRIPTION
## Summary
- preload py7zr during startup so PyInstaller always bundles the module
- reference pybcj and pyppmd codecs when available to hint PyInstaller about optional 7z extras

## Testing
- python -m compileall rom_manager/utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ca694e21548328a8eae3fe3389713f