### PR TITLE
Add ROM list import for basket

### DIFF
--- a/rom_manager/database.py
+++ b/rom_manager/database.py
@@ -83,6 +83,22 @@ class Database:
         )
         return ["Todos"] + [r[0] for r in cur.fetchall()]
 
+    def get_rom_names_by_system(self, system_id: int) -> List[sqlite3.Row]:
+        """
+        Obtiene todos los nombres de ROM disponibles para un sistema concreto.
+
+        Se devuelve una lista de filas con ``rom_id`` y ``rom_name`` para
+        facilitar la construcción de búsquedas exactas por nombre en la
+        interfaz de usuario.
+        """
+        assert self.conn
+        sql = (
+            "SELECT roms.id AS rom_id, roms.name AS rom_name "
+            "FROM roms WHERE roms.system_id = ? ORDER BY roms.name"
+        )
+        cur = self.conn.execute(sql, (system_id,))
+        return cur.fetchall()
+
     def search_links(
         self,
         text: str = "",


### PR DESCRIPTION
## Summary
- add a text-list importer to the ROM selector that parses filenames and queues the matches for the selected system
- reuse shared helpers to create basket entries from database links and report missing or duplicate ROM names
- expose a database helper to list ROM names per system for fast lookups

## Testing
- python -m compileall rom_manager

------
https://chatgpt.com/codex/tasks/task_e_68cfddaf6cb88328b3a3a75ae654b68d