### PR TITLE
Integrar soporte de gamepad en segundo plano para modo consola

### DIFF
--- a/rom_manager/console_input.py
+++ b/rom_manager/console_input.py
@@ -1,130 +1,161 @@
 """Controlador de entrada para el modo consola basado en pygame.
 
 Se integra con :class:`rom_manager.gui.main_window.MainWindow` para manejar
-mandos sin bloquear el bucle de eventos de Qt. Cuando el modo consola está
-activo se inicializa ``pygame.joystick`` y se leen los eventos mediante un
-``QTimer`` que mantiene actualizada la lista de dispositivos y traduce sus
-entradas en acciones de navegación.
+mandos sin bloquear el bucle de eventos de Qt. Los eventos se capturan en un
+hilo dedicado y se reenvían a la UI exclusivamente mediante señales de Qt.
 """
 from __future__ import annotations
 
 import logging
 import os
-from typing import Dict, TYPE_CHECKING
+import threading
+import time
+from typing import TYPE_CHECKING, Optional
 
-from PyQt6.QtCore import QObject, QTimer
+from PyQt6.QtCore import QObject, pyqtSignal
 
 if TYPE_CHECKING:
     from rom_manager.gui.main_window import MainWindow
 
 
-class PygameConsoleController(QObject):
-    """Gestiona mandos a través de pygame para el modo consola."""
+class GamepadReader(QObject):
+    """Lector de eventos de gamepad en un hilo en segundo plano."""
 
-    POLL_INTERVAL_MS = 50
+    buttonPressed = pyqtSignal(int)
+    axisMoved = pyqtSignal(int, float)
+    hatMoved = pyqtSignal(int, int)
 
-    def __init__(self, window: "MainWindow") -> None:
-        super().__init__(window)
-        self.window = window
+    POLL_INTERVAL_S = 0.04
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
         self._pygame = None
-        self._joysticks: Dict[int, object] = {}
-        self._timer = QTimer(self)
-        self._timer.setInterval(self.POLL_INTERVAL_MS)
-        self._timer.timeout.connect(self._poll_events)
+        self._joystick = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
 
-    # --- Ciclo de vida ---
     def start(self) -> None:
-        """Inicializa pygame y comienza a leer eventos de mando."""
-        if not self._initialize():
+        """Inicia el hilo de lectura del mando si aún no está activo."""
+        if self._thread and self._thread.is_alive():
             return
-        if not self._timer.isActive():
-            self._timer.start()
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, name="gamepad-reader", daemon=True)
+        self._thread.start()
 
     def stop(self) -> None:
-        """Detiene la lectura de eventos y libera recursos."""
-        try:
-            if self._timer.isActive():
-                self._timer.stop()
-        except Exception:
-            logging.exception("No se pudo detener el temporizador de mandos")
-        self._shutdown_pygame()
+        """Detiene el hilo y libera recursos de pygame."""
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=1.5)
+        self._thread = None
+        self._shutdown()
 
-    # --- Inicialización y limpieza ---
     def _initialize(self) -> bool:
         if self._pygame:
             return True
         try:
+            os.environ["SDL_VIDEODRIVER"] = "dummy"
+            os.environ["SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS"] = "1"
+
             import pygame
 
-            os.environ.setdefault("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", "1")
+            pygame.init()
+            pygame.display.set_mode((1, 1))
             pygame.joystick.init()
+
+            if pygame.joystick.get_count() > 0:
+                joystick = pygame.joystick.Joystick(0)
+                joystick.init()
+                self._joystick = joystick
+            else:
+                self._joystick = None
+
             self._pygame = pygame
-            self._refresh_devices()
-            logging.debug("pygame.joystick inicializado para el modo consola")
             return True
         except Exception:
-            logging.exception("No se pudo inicializar pygame para los mandos")
+            logging.exception("No se pudo inicializar pygame para lectura de gamepad")
             self._pygame = None
-            self._joysticks.clear()
+            self._joystick = None
             return False
 
-    def _shutdown_pygame(self) -> None:
+    def _shutdown(self) -> None:
         if not self._pygame:
             return
         try:
+            if self._joystick is not None:
+                self._joystick.quit()
             self._pygame.joystick.quit()
             self._pygame.quit()
         except Exception:
-            logging.exception("Error al cerrar pygame")
+            logging.exception("Error al cerrar pygame/gamepad")
         finally:
             self._pygame = None
-            self._joysticks.clear()
+            self._joystick = None
 
-    def _refresh_devices(self) -> None:
-        if not self._pygame:
+    def _run_loop(self) -> None:
+        if not self._initialize():
             return
-        self._joysticks.clear()
-        try:
-            for idx in range(self._pygame.joystick.get_count()):
-                joy = self._pygame.joystick.Joystick(idx)
-                self._joysticks[joy.get_instance_id()] = joy
-        except Exception:
-            logging.exception("No se pudo refrescar la lista de mandos")
+        while not self._stop_event.is_set():
+            if not self._pygame:
+                break
+            try:
+                for event in self._pygame.event.get():
+                    if event.type == self._pygame.JOYDEVICEADDED:
+                        if self._joystick is None and self._pygame.joystick.get_count() > 0:
+                            joystick = self._pygame.joystick.Joystick(0)
+                            joystick.init()
+                            self._joystick = joystick
+                    elif event.type == self._pygame.JOYDEVICEREMOVED:
+                        if self._pygame.joystick.get_count() <= 0:
+                            self._joystick = None
+                    elif event.type == self._pygame.JOYBUTTONDOWN:
+                        self.buttonPressed.emit(int(event.button))
+                    elif event.type == self._pygame.JOYHATMOTION:
+                        x, y = event.value
+                        self.hatMoved.emit(int(x), int(y))
+                    elif event.type == self._pygame.JOYAXISMOTION:
+                        self.axisMoved.emit(int(event.axis), float(event.value))
+            except Exception:
+                logging.exception("Error procesando eventos de gamepad")
+            time.sleep(self.POLL_INTERVAL_S)
 
-    # --- Procesamiento de eventos ---
-    def _poll_events(self) -> None:
-        if not self.window.console_mode_enabled:
-            return
-        if not self._pygame and not self._initialize():
-            return
-        if not self._pygame:
-            return
-        try:
-            for event in self._pygame.event.get():
-                if event.type == self._pygame.JOYDEVICEADDED:
-                    self._refresh_devices()
-                elif event.type == self._pygame.JOYDEVICEREMOVED:
-                    self._refresh_devices()
-                elif event.type == self._pygame.JOYBUTTONDOWN:
-                    self._handle_button(event.button)
-                elif event.type == self._pygame.JOYHATMOTION:
-                    self._handle_hat(event.value)
-        except Exception:
-            logging.exception("Error al procesar eventos de pygame")
+        self._shutdown()
 
-    # --- Traducción de entradas a acciones ---
-    _CONFIRM_BUTTONS = {0, 2}
-    _BACK_BUTTONS = {1, 6}
+
+class PygameConsoleController(QObject):
+    """Traduce eventos del mando a acciones de :class:`MainWindow`."""
+
+    _CONFIRM_BUTTONS = {0}
+    _BACK_BUTTONS = {1}
     _TAB_LEFT_BUTTONS = {4}
     _TAB_RIGHT_BUTTONS = {5}
-    _TOGGLE_MODE_BUTTONS = {7, 9, 10}
+    _OPEN_DOWNLOADS_BUTTONS = {6}
+    _OPEN_OPTIONS_BUTTONS = {7}
 
-    def _handle_button(self, button: int) -> None:
+    _AXIS_DEADZONE = 0.55
+
+    def __init__(self, window: "MainWindow") -> None:
+        super().__init__(window)
+        self.window = window
+        self.reader = GamepadReader(self)
+        self.reader.buttonPressed.connect(self._on_button_pressed)
+        self.reader.hatMoved.connect(self._on_hat_moved)
+        self.reader.axisMoved.connect(self._on_axis_moved)
+
+    def start(self) -> None:
+        self.reader.start()
+
+    def stop(self) -> None:
+        self.reader.stop()
+
+    def _on_button_pressed(self, button: int) -> None:
+        if not self.window.console_mode_enabled:
+            return
         if button in self._CONFIRM_BUTTONS:
-            self.window.trigger_console_activate()
+            self.window.on_gamepad_button_pressed(button)
             return
         if button in self._BACK_BUTTONS:
-            self.window.trigger_console_back()
+            self.window.on_gamepad_button_pressed(button)
             return
         if button in self._TAB_LEFT_BUTTONS:
             self.window.trigger_console_tab_left()
@@ -132,17 +163,28 @@ class PygameConsoleController(QObject):
         if button in self._TAB_RIGHT_BUTTONS:
             self.window.trigger_console_tab_right()
             return
-        if button in self._TOGGLE_MODE_BUTTONS:
-            self.window.trigger_console_toggle()
+        if button in self._OPEN_OPTIONS_BUTTONS:
+            self.window.trigger_console_open_options()
             return
+        if button in self._OPEN_DOWNLOADS_BUTTONS:
+            self.window.trigger_console_open_downloads()
 
-    def _handle_hat(self, value: tuple[int, int]) -> None:
-        x, y = value
-        if y > 0:
-            self.window.trigger_console_focus_prev()
-        elif y < 0:
-            self.window.trigger_console_focus_next()
-        elif x < 0:
-            self.window.trigger_console_focus_prev()
-        elif x > 0:
-            self.window.trigger_console_focus_next()
+    def _on_hat_moved(self, x: int, y: int) -> None:
+        if not self.window.console_mode_enabled:
+            return
+        if x == 0 and y == 0:
+            return
+        self.window.on_gamepad_hat_moved(x, y)
+
+    def _on_axis_moved(self, axis: int, value: float) -> None:
+        if not self.window.console_mode_enabled:
+            return
+        if axis not in (0, 1):
+            return
+        if abs(value) < self._AXIS_DEADZONE:
+            return
+        dx = -1 if axis == 0 and value < 0 else (1 if axis == 0 and value > 0 else 0)
+        dy = -1 if axis == 1 and value < 0 else (1 if axis == 1 and value > 0 else 0)
+        if dx == 0 and dy == 0:
+            return
+        self.window.on_gamepad_axis_moved(axis, value)


### PR DESCRIPTION
### Motivation
- Añadir soporte completo para controlar la UI con un mando (Xbox u otro) sin bloquear el hilo de Qt y sin requerir teclado/ratón.
- Evitar el error "video system not initialized" y permitir capturar eventos de joystick aunque la ventana Qt no tenga foco.
- Mantener la integridad de la GUI evitando modificar widgets desde hilos externos y usando señales Qt para comunicar eventos.

### Description
- Implementé un lector `GamepadReader(QObject)` en `rom_manager/console_input.py` que arranca en un hilo separado, inicializa SDL en modo headless (`os.environ['SDL_VIDEODRIVER']='dummy'`, `os.environ['SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS']='1'`, `pygame.init()`, `pygame.display.set_mode((1,1))`), abre el primer joystick y emite señales Qt (`buttonPressed`, `axisMoved`, `hatMoved`) al detectar `JOYBUTTONDOWN`, `JOYAXISMOTION` y `JOYHATMOTION`.
- Reescribí/actualicé `PygameConsoleController` para suscribirse a las señales del lector y traducirlas a acciones de la ventana principal sin tocar la GUI desde el hilo de pygame (mapeos para A/B, LB/RB, Start/Back, hats y ejes con deadzone).
- Extendí `MainWindow` (`rom_manager/gui/main_window.py`) con nuevos slots y utilidades: navegación entre pestañas (`trigger_console_tab_left/right`, `trigger_console_open_options`, `trigger_console_open_downloads`), movimiento de selección en `QTableWidget/QTableView/QListWidget` (`_move_selection`), disparo de la acción por defecto en la fila enfocada (`_trigger_default_for_focused_widget`), cierre de diálogos activos (`_close_active_dialog`) y handlers `on_gamepad_button_pressed`, `on_gamepad_hat_moved`, `on_gamepad_axis_moved` para recibir las señales y aplicar cambios en la UI.
- Mejoré `_show_virtual_keyboard()` para intentar mostrar el teclado en pantalla según plataforma además de usar `QGuiApplication.inputMethod().show()` (busca `osk.exe`/`TabTip.exe` en Windows o `onboard` en Linux y los lanza si están disponibles).
- Aseguré el ciclo de vida del lector: el controlador se crea y se arranca al inicializar la `MainWindow` y se detiene al cerrar la ventana liberando joystick y llamando a `pygame.quit()`.

### Testing
- Compilación estática ejecutada con `python -m compileall rom_manager` y completó sin errores (archivos compilados correctamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699233bba84c8328821c50d166945483)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced gamepad support with improved input responsiveness and event handling
  * Added virtual keyboard launcher for Windows and other platforms
  * Improved console mode navigation for gamepad and keyboard users

* **Improvements**
  * Refined gamepad input processing for better reliability
  * Better focus navigation and widget control within the UI
  * Streamlined console mode workflow for enhanced user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->